### PR TITLE
Add Dockerfile for local Jekyll test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM jekyll/jekyll
+
+WORKDIR /srv/jekyll
+
+COPY . /srv/jekyll
+
+RUN chown -R jekyll:jekyll /srv/jekyll
+
+ENTRYPOINT ["jekyll", "serve"]


### PR DESCRIPTION
- To build an Docker image:
`docker build --tag cb-website .`
- To run `cb-website` container:
`docker run -p 4000:4000 cb-website`
- To access the local Jekyll website:
http://host:4000