### PR TITLE
Add files for redirect test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,3 +28,4 @@ end
 # Performance-booster for watching directories on Windows
 gem "wdm", "~> 0.1.1", :install_if => Gem.win_platform?
 
+gem 'jekyll-redirect-from'

--- a/_config.yml
+++ b/_config.yml
@@ -115,3 +115,9 @@ testimonial:
     message: "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged."
     author: Marcel Newman
     position: WEB DESIGNER - BLACKTIE.CO
+
+plugins:
+  - jekyll-redirect-from
+
+whitelist:
+  - jekyll-redirect-from

--- a/redirects/test-docs.html
+++ b/redirects/test-docs.html
@@ -1,0 +1,5 @@
+---
+permalink: /test-docs
+redirect_to:
+  - https://github.com/cloud-barista/docs
+---

--- a/redirects/test-facebook.html
+++ b/redirects/test-facebook.html
@@ -1,0 +1,5 @@
+---
+layout:     redirect
+permalink:  /test-facebook
+redirect:   https://www.facebook.com/groups/cloud.barista.community
+---


### PR DESCRIPTION
- Related issue: #5 
- 현재 Redirect 를 위한 html 파일들이 repo root 에 많이 있는데, 
이를 하나의 디렉토리 (예: `redirects`) 아래에 모을 수 있을지에 대한 테스트입니다.
- 다음의 [두 가지 방법](https://superdevresources.com/redirects-jekyll-github-pages/)에 대해 테스트합니다.
  1. [jekyll-redirect-from](https://github.com/jekyll/jekyll-redirect-from) 플러그인을 사용하는 방법
  2. 현재 되어있는 것과 같이, redirect 용 layout 을 활용하는 방법
- 이 PR이 머지되었을 때의 예상 결과
  - https://cloud-barista.github.io/test-docs 으로 접속하면
  https://github.com/cloud-barista/docs 으로 redirect (by 첫 번째 방법)
  - https://cloud-barista.github.io/test-facebook 으로 접속하면
  https://www.facebook.com/groups/cloud.barista.community 으로 redirect (by 두 번째 방법)

@innodreamer 확인 부탁 드립니다.. ^^