### PR TITLE
Update for the release of cafemocha

### DIFF
--- a/_posts/2021-06-30-4th-Open-Conference-and-v0.4.0-cafemocha-Open.markdown
+++ b/_posts/2021-06-30-4th-Open-Conference-and-v0.4.0-cafemocha-Open.markdown
@@ -1,8 +1,8 @@
 ---
 layout: post
 title: Blog
-post_title: "[공지] 제4차 오픈 컨퍼런스 발표 자료와 발표 영상을 공유해드립니다"
-date: 2021-06-25 20:50:35
+post_title: "[공지] 4차 오픈 컨퍼런스 발표자료와 v0.4.0-cafemocha를 공유해드립니다"
+date: 2021-06-30 15:00:25
 author: 오병택
 categories: 
 - 공지
@@ -76,3 +76,20 @@ categories:
 | 에필로그 | 강동재<BR>커뮤니티 리더 | - | [[YouTube](https://youtu.be/gIEsqneNqoo){:target="_blank"}] |
 
 <BR>
+
+#### 4차 오픈 컨퍼런스 질의사항 답변서(Q&A report) 다운로드
+
+* [질의사항 답변서(Q&A Report) 다운로드](https://github.com/cloud-barista/docs/blob/master/openseminar/v0.4.0-cafemocha/Cloud-Barista_4th_Open_Conference_QnA_Report.pdf "github.com/cloud-barista/docs/blob/master/openseminar/v0.4.0-cafemocha/Cloud-Barista_4th_Open_Conference_QnA_Report.pdf"){:target="_blank"}
+
+<BR>
+
+
+#### Cloud-Barista v0.4.0 CafeMocha 공개
+
+* [v0.4.0-cafemocha 소스 코드 및 설치 가이드](https://github.com/cloud-barista/cloud-barista/tree/release-0.4.0 "github.com/cloud-barista/cloud-barista/tree/release-0.4.0"){:target="_blank"}
+
+<BR>
+
+#### 2021년도 하반기에도 5차 오픈 컨퍼런스가 진행될 예정이니 많은 관심 부탁드립니다.
+
+* (참고) [Cloud-Barista Community Open Seminar Milestone](https://cloud-barista.github.io/community/ "Cloud-Barista Open Seminar Milestone"){:target="_blank"}

--- a/download.html
+++ b/download.html
@@ -16,32 +16,45 @@ permalink: /download/
               <!--ul class=”list-inline“>
                   <li>Cloud-Barista GitHub : <a href="https://github.com/cloud-barista" target="_New">https://github.com/cloud-barista</a></li>
               </ul-->
-              <BR>
-                <ul>
-                    <li>
-                      <B>Cloud-Barista v0.3.0-espresso</B>
+              <ul>
+                  <li>
+                    <B>Cloud-Barista v0.4.0-cafemocha</B>
                     <ul>
-                        <li><a href="https://github.com/cloud-barista/cloud-barista/releases/tag/v0.3.0-espresso/" target="_New">소스 코드 (Changelog, zip 파일)</a></li>
-                        <li><a href="https://github.com/cloud-barista/cloud-barista/blob/v0.3.0-espresso/README.md" target="_New">설치 가이드</a></li>
-                        <li><a href="https://github.com/cloud-barista/docs/blob/master/technical_docs/API/CB-User_REST-API.md#v030-espresso" target="_New">API 규격</a></li>
-                        <li><a href="https://github.com/cloud-barista/docs/tree/master/technical_docs" target="_New">기술 문서</a></li>
-                        <li><a href="https://github.com/cloud-barista/docs/tree/master/openseminar/v0.3.0-espresso" target="_New">오픈 행사 발표자료 및 발표영상(YouTube)</a></li>
-                        <li><a href="https://www.slideshare.net/cloud-barista/presentations" target="_New">오픈 행사 발표자료 (SlideShare)</a></li>
+                      <li><a href="https://github.com/cloud-barista/cloud-barista/releases/tag/v0.4.0/" target="_New">v0.4.0-cafemocha 소스 코드 (Changelog, zip 파일)</a></li>
+                      <li><a href="https://github.com/cloud-barista/cloud-barista/blob/v0.4.0-cafemocha/README.md" target="_New">v0.4.0-cafemocha 설치 가이드</a></li>
+                      <li><a href="https://github.com/cloud-barista/docs/blob/master/technical_docs/API/CB-User_REST-API.md#v040-cafemocha" target="_New">v0.4.0-cafemocha REST API 규격</a></li>
+                      <li><a href="https://github.com/cloud-barista/docs/tree/master/openseminar/v0.4.0-cafemocha" target="_New">4차 오픈 컨퍼런스 발표자료 및 발표영상(YouTube)</a></li>
+                      <li><a href="https://www.slideshare.net/cloud-barista/presentations" target="_New">4차 오픈 컨퍼런스 발표자료 (SlideShare)</a></li>
+                      <li><a href="https://github.com/cloud-barista/docs/tree/master/technical_docs" target="_New">기술 문서</a></li>
                     </ul>
-                    </li>
-                </ul>
+                  </li>
+              </ul>
+              <BR>
+              <ul>
+                  <li>
+                    <B>Cloud-Barista v0.3.0-espresso</B>
+                    <ul>
+                      <li><a href="https://github.com/cloud-barista/cloud-barista/releases/tag/v0.3.0-espresso/" target="_New">v0.3.0-espresso 소스 코드 (Changelog, zip 파일)</a></li>
+                      <li><a href="https://github.com/cloud-barista/cloud-barista/blob/v0.3.0-espresso/README.md" target="_New">v0.3.0-espresso 설치 가이드</a></li>
+                      <li><a href="https://github.com/cloud-barista/docs/blob/master/technical_docs/API/CB-User_REST-API.md#v030-espresso" target="_New">v0.3.0-espresso REST API 규격</a></li>
+                      <li><a href="https://github.com/cloud-barista/docs/tree/master/openseminar/v0.3.0-espresso" target="_New">3차 오픈 컨퍼런스 발표자료 및 발표영상(YouTube)</a></li>
+                      <li><a href="https://www.slideshare.net/cloud-barista/presentations" target="_New">3차 오픈 컨퍼런스 발표자료 (SlideShare)</a></li>
+                      <li><a href="https://github.com/cloud-barista/docs/tree/master/technical_docs" target="_New">기술 문서</a></li>
+                    </ul>
+                  </li>
+              </ul>
               <BR>
               <ul>
                   <li>
                     <B>Cloud-Barista v0.2.0-cappuccino</B>
-                  <ul>
-                      <li><a href="https://github.com/cloud-barista/cloud-barista/releases/tag/v0.2.0-cappuccino/" target="_New">소스 코드 (Changelog, zip 파일)</a></li>
-                      <li><a href="https://github.com/cloud-barista/cloud-barista/blob/v0.2.0-cappuccino/README.md" target="_New">설치 가이드</a></li>
-                      <li><a href="https://github.com/cloud-barista/docs/blob/master/technical_docs/API/CB-User_REST-API.md#v020-cappuccino" target="_New">API 규격</a></li>
+                    <ul>
+                      <li><a href="https://github.com/cloud-barista/cloud-barista/releases/tag/v0.2.0-cappuccino/" target="_New">v0.2.0-cappuccino 소스 코드 (Changelog, zip 파일)</a></li>
+                      <li><a href="https://github.com/cloud-barista/cloud-barista/blob/v0.2.0-cappuccino/README.md" target="_New">v0.2.0-cappuccino 설치 가이드</a></li>
+                      <li><a href="https://github.com/cloud-barista/docs/blob/master/technical_docs/API/CB-User_REST-API.md#v020-cappuccino" target="_New">v0.2.0-cappuccino REST API 규격</a></li>
+                      <li><a href="https://github.com/cloud-barista/docs/tree/master/openseminar/v0.2.0-cappuccino" target="_New">2차 오픈 컨퍼런스 발표자료 및 발표영상(YouTube)</a></li>
+                      <li><a href="https://www.slideshare.net/cloud-barista/presentations" target="_New">2차 오픈 컨퍼런스 발표자료 (SlideShare)</a></li>
                       <li><a href="https://github.com/cloud-barista/docs/tree/master/technical_docs" target="_New">기술 문서</a></li>
-                      <li><a href="https://github.com/cloud-barista/docs/tree/master/openseminar/v0.2.0-cappuccino" target="_New">오픈 행사 발표자료 및 발표영상(YouTube)</a></li>
-                      <li><a href="https://www.slideshare.net/cloud-barista/presentations" target="_New">오픈 행사 발표자료 (SlideShare)</a></li>
-                  </ul>
+                    </ul>
                   </li>
               </ul>
               <BR>
@@ -49,13 +62,13 @@ permalink: /download/
                   <li>
                     <B>Cloud-Barista v0.1.0-americano</B>
                     <ul>
-                      <li><a href="https://github.com/cloud-barista/cloud-barista/releases/tag/v0.1.0-americano/" target="_New">소스 코드 (zip 파일)</a></li>
-                      <li><a href="https://github.com/cloud-barista/cloud-barista/blob/v0.1.0-americano/README.md" target="_New">설치 가이드</a></li>
-                      <li><a href="https://github.com/cloud-barista/docs/blob/master/technical_docs/API/CB-User_REST-API.md#v010-americano" target="_New">API 규격</a></li>
+                      <li><a href="https://github.com/cloud-barista/cloud-barista/releases/tag/v0.1.0-americano/" target="_New">v0.1.0-americano 소스 코드 (zip 파일)</a></li>
+                      <li><a href="https://github.com/cloud-barista/cloud-barista/blob/v0.1.0-americano/README.md" target="_New">v0.1.0-americano 설치 가이드</a></li>
+                      <li><a href="https://github.com/cloud-barista/docs/blob/master/technical_docs/API/CB-User_REST-API.md#v010-americano" target="_New">v0.1.0-americano REST API 규격</a></li>
                       <li><a href="https://github.com/cloud-barista/docs/tree/master/technical_docs" target="_New">기술 문서</a></li>
                       <li><a href="https://github.com/cloud-barista/docs/tree/master/openseminar/v0.1.0-americano" target="_New">오픈 행사 발표자료 (GitHub PDF)</a></li>
                       <li><a href="https://www.slideshare.net/cloud-barista/presentations" target="_New">오픈 행사 발표자료 (SlideShare)</a></li>
-                  </ul>
+                    </ul>
                   </li>
               </ul>
              

--- a/redirects/rd-rest-api-v0.4.0-dragonfly.html
+++ b/redirects/rd-rest-api-v0.4.0-dragonfly.html
@@ -1,0 +1,7 @@
+---
+layout:     redirect
+title:      REST-API
+api-version: v0.4.0
+permalink:  /rest-api/v0.4.0/dragonfly/
+redirect:   https://documenter.getpostman.com/view/7454078/TzkyLKJy
+---

--- a/redirects/rd-rest-api-v0.4.0-ladybug.html
+++ b/redirects/rd-rest-api-v0.4.0-ladybug.html
@@ -1,0 +1,7 @@
+---
+layout:     redirect
+title:      REST-API
+api-version: v0.4.0
+permalink:  /rest-api/v0.4.0/ladybug/
+redirect:   https://cloud-barista.github.io/cb-ladybug-api-web/?url=https://raw.githubusercontent.com/cloud-barista/cb-ladybug/master/src/docs/v0.4.0.yaml
+---

--- a/redirects/rd-rest-api-v0.4.0-tumblebug.html
+++ b/redirects/rd-rest-api-v0.4.0-tumblebug.html
@@ -1,0 +1,7 @@
+---
+layout:     redirect
+title:      REST-API
+api-version: v0.4.0
+permalink:  /rest-api/v0.4.0/tumblebug/
+redirect:   https://cloud-barista.github.io/cb-tumblebug-api-web/?url=https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/main/src/api/rest/docs/v0.4.0.yaml
+---

--- a/redirects/test-docs.html
+++ b/redirects/test-docs.html
@@ -1,5 +1,0 @@
----
-permalink: /test-docs
-redirect_to:
-  - https://github.com/cloud-barista/docs
----

--- a/redirects/test-facebook.html
+++ b/redirects/test-facebook.html
@@ -1,5 +1,0 @@
----
-layout:     redirect
-permalink:  /test-facebook
-redirect:   https://www.facebook.com/groups/cloud.barista.community
----

--- a/rest-api-list.html
+++ b/rest-api-list.html
@@ -9,6 +9,137 @@ permalink: /rest-api/
 
         <!-- REST APIs LIST -->
         <div class="col-md-9 col-lg-offset-2">
+            <table class="table table-bordered">
+                <tbody>
+                <tr class="table-primary">
+                    <td class="table-primary">
+    
+                    <h3>Cloud-Barista User REST API (v0.4.0-cafemocha)</h3>
+                    <p>&nbsp;</p>
+
+                    <h4>[클라우드 인프라 연동 정보 통합 관리 (CB-Spider)] </h4>
+                    <ul>
+                    <li>클라우드 인프라 연결을 위한 정보 등록 및 관리</li>
+                    <li>API 규격/샘플: <a href='https://cloud-barista.github.io/rest-api/v0.4.0/spider/ccim/' target='_blank' class='url'>https://cloud-barista.github.io/rest-api/v0.4.0/spider/ccim/</a></li>
+                    <li>Maintainer: <a href='https://github.com/powerkimhub' title='https://github.com/powerkimhub' target='_blank'>@powerkimhub</a></li>
+                    </ul>
+
+                    <hr>
+                    <h4>[멀티 클라우드 인프라 서비스 통합 관리 (CB-Tumblebug)]</h4>
+                    <ul>
+                    <li>네임스페이스 생성 및 관리, MCIR 등록/생성 및 관리, MCIS 생성/제어 및 관리</li>
+                    <li>API 규격/샘플: <a href='https://cloud-barista.github.io/rest-api/v0.4.0/tumblebug/' target='_blank' class='url'>https://cloud-barista.github.io/rest-api/v0.4.0/tumblebug/</a></li>
+                    <li>Maintainer: <a href='https://github.com/seokho-son' title='https://github.com/seokho-son' target='_blank'>@seokho-son</a> <a href='https://github.com/jihoon-seo' title='https://github.com/jihoon-seo' target='_blank'>@jihoon-seo</a></li>
+                    </ul>
+                                      
+                    <hr>
+                    <h4>[멀티 클라우드 애플리케이션 운용 관리 (CB-Ladybug)]</h4>
+                    <ul>
+                    <li>클러스터 생성/삭제/정보 조회, 노드 추가, 삭제, 정보 조회</li>
+                    <li>API 규격/샘플: <a href='https://cloud-barista.github.io/rest-api/v0.4.0/ladybug/' target='_blank' class='url'>https://cloud-barista.github.io/rest-api/v0.4.0/ladybug/</a></li>
+                    <li>Maintainer: <a href='https://github.com/sykim-etri' title='https://github.com/sykim-etri' target='_blank'>@sykim-etri</a></li>
+                    </ul>
+    
+                    <hr>
+                    <h4>[멀티 클라우드 인프라 서비스 통합 모니터링 (CB-Dragonfly)]</h4>
+                    <ul>
+                    <li>MCIS 및 VM 모니터링(온디멘드 모니터링 조회, MCIS 모니터링 조회, 알람 이벤트 핸들러 관리 및 알람 관리)</li>
+                    <li>API 규격/샘플: <a href='https://cloud-barista.github.io/rest-api/v0.4.0/dragonfly/' target='_blank' class='url'>https://cloud-barista.github.io/rest-api/v0.4.0/dragonfly/</a></li>
+
+                    <li>Maintainer: <a href='https://github.com/hyokyungk' title='https://github.com/hyokyungk' target='_blank'>@hyokyungk</a></li>
+                    </ul>
+
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+        </div>
+    
+                <p>&nbsp;</p>
+
+
+        <div class="col-md-9 col-lg-offset-2">
+            <table class="table table-bordered">
+                <tbody>
+                <tr class="table-primary">
+                    <td class="table-primary">
+    
+                    <h3>Cloud-Barista User REST API (v0.3.0-espresso)</h3>
+                    <p>&nbsp;</p>
+
+                    <h4>[클라우드 인프라 연동 정보 통합 관리 (CB-Spider)] </h4>
+                    <ul>
+                    <li>클라우드 인프라 연결을 위한 정보 등록 및 관리</li>
+                    <li>API 규격/샘플: <a href='https://cloud-barista.github.io/rest-api/v0.3.0/spider/ccim/' target='_blank' class='url'>https://cloud-barista.github.io/rest-api/v0.3.0/spider/ccim/</a></li>
+                    <li>Maintainer: <a href='https://github.com/powerkimhub' title='https://github.com/powerkimhub' target='_blank'>@powerkimhub</a></li>
+                    </ul>
+
+                    <hr>
+                    <h4>[멀티 클라우드 인프라 서비스 통합 관리 (CB-Tumblebug)]</h4>
+                    <h6>[멀티 클라우드 네임스페이스 관리]</h6>
+                    <ul>
+                    <li>작업 공간 분리를 위한 네임스페이스 생성 및 관리</li>
+                    <li>API 규격/샘플: <a href='https://cloud-barista.github.io/cb-tumblebug-api-web/?url=https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/main/src/api/rest/docs/v0.3.0.yaml#/Namespace' target='_blank' class='url'>[Namespace API]</a></li>
+                    <li>Maintainer: <a href='https://github.com/seokho-son' title='https://github.com/seokho-son' target='_blank'>@seokho-son</a> <a href='https://github.com/jihoon-seo' title='https://github.com/jihoon-seo' target='_blank'>@jihoon-seo</a></li>
+                    </ul>
+                    
+                    <h6>[멀티 클라우드 인프라 자원(MCIR) 관리]</h6>
+                    <ul>
+                    <li>MCIR관련 등록/생성 및 관리</li>
+                    <dl>
+                        <li><dt>API 규격/샘플: </dt></li>
+                        <dd>- Image : <a href='https://cloud-barista.github.io/cb-tumblebug-api-web/?url=https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/main/src/api/rest/docs/v0.3.0.yaml#/Image' target='_blank' class='url'>[MCIR Image API]</a></dd>
+
+                        <dd>- Spec : <a href='https://cloud-barista.github.io/cb-tumblebug-api-web/?url=https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/main/src/api/rest/docs/v0.3.0.yaml#/Spec' target='_blank' class='url'>[MCIR Spec API]</a></dd>
+
+                        <dd>- VNet : <a href='https://cloud-barista.github.io/cb-tumblebug-api-web/?url=https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/main/src/api/rest/docs/v0.3.0.yaml#/VNet' target='_blank' class='url'>[MCIR VNet API]</a></dd>
+                        
+                        <dd>- SecurityGroup : <a href='https://cloud-barista.github.io/cb-tumblebug-api-web/?url=https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/main/src/api/rest/docs/v0.3.0.yaml#/Security%20Group' target='_blank' class='url'>[MCIR SecurityGroup API]</a></dd>
+
+                        <dd>- AccessKey : <a href='https://cloud-barista.github.io/cb-tumblebug-api-web/?url=https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/main/src/api/rest/docs/v0.3.0.yaml#/SSH%20Key' target='_blank' class='url'>[MCIR AccessKey API]</a></dd>
+                    </dl>
+                    <li>Maintainer: <a href='https://github.com/jihoon-seo' title='https://github.com/jihoon-seo' target='_blank'>@jihoon-seo</a> <a href='https://github.com/seokho-son' title='https://github.com/seokho-son' target='_blank'>@seokho-son</a></li>
+                    </ul>
+                    
+                    <h6>[멀티 클라우드 인프라 서비스(MCIS) 관리]</h6>
+                    <ul>
+                    <li>MCIS 생성/제어 및 관리</li>
+                    <dl>
+                        <li><dt>API 규격/샘플: </dt></li>
+                        <dd>- 생성 및 기본 제어 : <a href='https://cloud-barista.github.io/cb-tumblebug-api-web/?url=https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/main/src/api/rest/docs/v0.3.0.yaml#/MCIS' target='_blank' class='url'>[MCIR Provisioning and  Lifecycle API]</a></dd>
+
+                        <dd>- 정책 기반 자동 관리 : <a href='https://cloud-barista.github.io/cb-tumblebug-api-web/?url=https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/main/src/api/rest/docs/v0.3.0.yaml#/MCIS%20Policy' target='_blank' class='url'>[MCIR Auto Management API]</a></dd>
+                    </dl>
+
+                    <li>Maintainer: <a href='https://github.com/seokho-son' title='https://github.com/seokho-son' target='_blank'>@seokho-son</a> <a href='https://github.com/jihoon-seo' title='https://github.com/jihoon-seo' target='_blank'>@jihoon-seo</a></li>
+                    </ul>
+                    
+                    <hr>
+                    <h4>[멀티 클라우드 애플리케이션 운용 관리 (CB-Ladybug)]</h4>
+                    <ul>
+                    <li>클러스터 생성/삭제/정보 조회, 노드 추가, 삭제, 정보 조회</li>
+                    <li>API 규격/샘플: <a href='https://cloud-barista.github.io/rest-api/v0.3.0/ladybug/' target='_blank' class='url'>https://cloud-barista.github.io/rest-api/v0.3.0/ladybug/</a></li>
+                    <li>Maintainer: <a href='https://github.com/sykim-etri' title='https://github.com/sykim-etri' target='_blank'>@sykim-etri</a></li>
+                    </ul>
+    
+                    <hr>
+                    <h4>[멀티 클라우드 인프라 서비스 통합 모니터링 (CB-Dragonfly)]</h4>
+                    <ul>
+                    <li>MCIS 및 VM 모니터링(온디멘드 모니터링 조회, MCIS 모니터링 조회, 알람 이벤트 핸들러 관리 및 알람 관리)</li>
+                    <li>API 규격/샘플: <a href='https://cloud-barista.github.io/rest-api/v0.3.0/dragonfly/' target='_blank' class='url'>https://cloud-barista.github.io/rest-api/v0.3.0/dragonfly/</a></li>
+
+                    <li>Maintainer: <a href='https://github.com/kyongminkwon' title='https://github.com/kyongminkwon' target='_blank'>@kyongminkwon</a> <a href='https://github.com/hyokyungk' title='https://github.com/hyokyungk' target='_blank'>@hyokyungk</a></li>
+                    </ul>
+
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+        </div>
+    
+                <p>&nbsp;</p>
+
+        <div class="col-md-9 col-lg-offset-2">
         <table class="table table-bordered">
             <tbody>
             <tr class="table-primary">
@@ -20,7 +151,7 @@ permalink: /rest-api/
                 <ul>
                 <li>클라우드 인프라 연결을 위한 정보 등록 및 관리</li>
                 <li>API 규격/샘플: <a href='https://cloud-barista.github.io/rest-api/v0.2.0/spider/ccim/' target='_blank' class='url'>https://cloud-barista.github.io/rest-api/v0.2.0/spider/ccim/</a></li>
-                <li>Leader: <a href='https://github.com/powerkimhub' title='https://github.com/powerkimhub' target='_blank'>@powerkimhub</a></li>
+                <li>Maintainer: <a href='https://github.com/powerkimhub' title='https://github.com/powerkimhub' target='_blank'>@powerkimhub</a></li>
                 </ul>
                 <hr>
                 <h4>[멀티 클라우드 인프라 서비스 통합 관리 (CB-Tumblebug)]</h4>
@@ -28,21 +159,21 @@ permalink: /rest-api/
                 <ul>
                 <li>작업 공간 분리를 위한 네임스페이스 생성 및 관리</li>
                 <li>API 규격/샘플: <a href='https://cloud-barista.github.io/rest-api/v0.2.0/tumblebug/namespace/' target='_blank' class='url'>https://cloud-barista.github.io/rest-api/v0.2.0/tumblebug/namespace/</a></li>
-                <li>Leader: <a href='https://github.com/seokho-son' title='https://github.com/seokho-son' target='_blank'>@seokho-son</a> <a href='https://github.com/jihoon-seo' title='https://github.com/jihoon-seo' target='_blank'>@jihoon-seo</a></li>
+                <li>Maintainer: <a href='https://github.com/seokho-son' title='https://github.com/seokho-son' target='_blank'>@seokho-son</a> <a href='https://github.com/jihoon-seo' title='https://github.com/jihoon-seo' target='_blank'>@jihoon-seo</a></li>
                 </ul>
                 
                 <h6>[멀티 클라우드 인프라 자원(MCIR) 관리]</h6>
                 <ul>
                 <li>MCIR관련 등록/생성 및 관리</li>
                 <li>API 규격/샘플: <a href='https://cloud-barista.github.io/rest-api/v0.2.0/tumblebug/mcir/' target='_blank' class='url'>https://cloud-barista.github.io/rest-api/v0.2.0/tumblebug/mcir/</a></li>
-                <li>Leader: <a href='https://github.com/jihoon-seo' title='https://github.com/jihoon-seo' target='_blank'>@jihoon-seo</a> <a href='https://github.com/seokho-son' title='https://github.com/seokho-son' target='_blank'>@seokho-son</a></li>
+                <li>Maintainer: <a href='https://github.com/jihoon-seo' title='https://github.com/jihoon-seo' target='_blank'>@jihoon-seo</a> <a href='https://github.com/seokho-son' title='https://github.com/seokho-son' target='_blank'>@seokho-son</a></li>
                 </ul>
                 
                 <h6>[멀티 클라우드 인프라 서비스(MCIS) 관리]</h6>
                 <ul>
                 <li>MCIS 생성/제어 및 관리</li>
                 <li>API 규격/샘플: <a href='https://cloud-barista.github.io/rest-api/v0.2.0/tumblebug/mcis/' target='_blank' class='url'>https://cloud-barista.github.io/rest-api/v0.2.0/tumblebug/mcis/</a></li>
-                <li>Leader: <a href='https://github.com/seokho-son' title='https://github.com/seokho-son' target='_blank'>@seokho-son</a> <a href='https://github.com/jihoon-seo' title='https://github.com/jihoon-seo' target='_blank'>@jihoon-seo</a></li>
+                <li>Maintainer: <a href='https://github.com/seokho-son' title='https://github.com/seokho-son' target='_blank'>@seokho-son</a> <a href='https://github.com/jihoon-seo' title='https://github.com/jihoon-seo' target='_blank'>@jihoon-seo</a></li>
                 </ul>
                 
                 <hr>
@@ -51,7 +182,7 @@ permalink: /rest-api/
                 <li>MCIS 및 VM 모니터링</li>
                 <li>모니터링 조회 시 UTC 시간 기준으로 time 값 전달</li>
                 <li>API 규격/샘플: <a href='https://cloud-barista.github.io/rest-api/v0.2.0/dragonfly/' target='_blank' class='url'>https://cloud-barista.github.io/rest-api/v0.2.0/dragonfly/</a></li>
-                <li>Leader: <a href='https://github.com/kyongminkwon' title='https://github.com/kyongminkwon' target='_blank'>@kyongminkwon</a> <a href='https://github.com/hyokyungk' title='https://github.com/hyokyungk' target='_blank'>@hyokyungk</a></li>
+                <li>Maintainer: <a href='https://github.com/kyongminkwon' title='https://github.com/kyongminkwon' target='_blank'>@kyongminkwon</a> <a href='https://github.com/hyokyungk' title='https://github.com/hyokyungk' target='_blank'>@hyokyungk</a></li>
                 </ul>
 
                 </td>
@@ -74,7 +205,7 @@ permalink: /rest-api/
                 <ul>
                 <li>클라우드 인프라 연결을 위한 정보 등록 및 관리</li>
                 <li>API 규격/샘플: <a href='https://cloud-barista.github.io/rest-api/v0.1.0/spider/ccim/' target='_blank' class='url'>https://cloud-barista.github.io/rest-api/v0.1.0/spider/ccim/</a></li>
-                <li>Leader: <a href='https://github.com/powerkimhub' title='https://github.com/powerkimhub' target='_blank'>@powerkimhub</a></li>
+                <li>Maintainer: <a href='https://github.com/powerkimhub' title='https://github.com/powerkimhub' target='_blank'>@powerkimhub</a></li>
 
                 </ul>
                 <hr>
@@ -83,21 +214,21 @@ permalink: /rest-api/
                 <ul>
                 <li>작업 공간 분리를 위한 네임스페이스 생성 및 관리</li>
                 <li>API 규격/샘플: <a href='https://cloud-barista.github.io/rest-api/v0.1.0/tumblebug/namespace/' target='_blank' class='url'>https://cloud-barista.github.io/rest-api/v0.1.0/tumblebug/namespace/</a></li>
-                <li>Leader: <a href='https://github.com/seokho-son' title='https://github.com/seokho-son' target='_blank'>@seokho-son</a> <a href='https://github.com/jihoon-seo' title='https://github.com/jihoon-seo' target='_blank'>@jihoon-seo</a></li>
+                <li>Maintainer: <a href='https://github.com/seokho-son' title='https://github.com/seokho-son' target='_blank'>@seokho-son</a> <a href='https://github.com/jihoon-seo' title='https://github.com/jihoon-seo' target='_blank'>@jihoon-seo</a></li>
                 </ul>
 
                 <h6>[멀티 클라우드 인프라 자원(MCIR) 관리]</h6>
                 <ul>
                 <li>MCIR관련 등록/생성 및 관리</li>
                 <li>API 규격/샘플: <a href='https://cloud-barista.github.io/rest-api/v0.1.0/tumblebug/mcir/' target='_blank' class='url'>https://cloud-barista.github.io/rest-api/v0.1.0/tumblebug/mcir/</a></li>
-                <li>Leader: <a href='https://github.com/jihoon-seo' title='https://github.com/jihoon-seo' target='_blank'>@jihoon-seo</a> <a href='https://github.com/seokho-son' title='https://github.com/seokho-son' target='_blank'>@seokho-son</a></li>
+                <li>Maintainer: <a href='https://github.com/jihoon-seo' title='https://github.com/jihoon-seo' target='_blank'>@jihoon-seo</a> <a href='https://github.com/seokho-son' title='https://github.com/seokho-son' target='_blank'>@seokho-son</a></li>
 
                 </ul>
                 <h6>[멀티 클라우드 인프라 서비스(MCIS) 관리]</h6>
                 <ul>
                 <li>MCIS 생성/제어 및 관리</li>
                 <li>API 규격/샘플: <a href='https://cloud-barista.github.io/rest-api/v0.1.0/tumblebug/mcis/' target='_blank' class='url'>https://cloud-barista.github.io/rest-api/v0.1.0/tumblebug/mcis/</a></li>
-                <li>Leader: <a href='https://github.com/seokho-son' title='https://github.com/seokho-son' target='_blank'>@seokho-son</a> <a href='https://github.com/jihoon-seo' title='https://github.com/jihoon-seo' target='_blank'>@jihoon-seo</a></li>
+                <li>Maintainer: <a href='https://github.com/seokho-son' title='https://github.com/seokho-son' target='_blank'>@seokho-son</a> <a href='https://github.com/jihoon-seo' title='https://github.com/jihoon-seo' target='_blank'>@jihoon-seo</a></li>
                 </ul>
                 <BR>
 
@@ -105,7 +236,7 @@ permalink: /rest-api/
                 <ul>
                 <li>동일 Subnet &amp; Load Balancing 기능</li>
                 <li>API 규격/샘플: <a href='https://cloud-barista.github.io/rest-api/v0.1.0/tumblebug/special-svc/' target='_blank' class='url'>https://cloud-barista.github.io/rest-api/v0.1.0/tumblebug/special-svc/</a></li>
-                <li>Leader: <a href='https://github.com/innodreamer' title='https://github.com/innodreamer' target='_blank'>@innodreamer</a></li>
+                <li>Maintainer: <a href='https://github.com/innodreamer' title='https://github.com/innodreamer' target='_blank'>@innodreamer</a></li>
                 </ul>
                 <hr>
 
@@ -114,7 +245,7 @@ permalink: /rest-api/
                 <li>MCIS 및 VM 모니터링</li>
                 <li>모니터링 조회 시 UTC 시간 기준으로 time 값 전달</li>
                 <li>API 규격/샘플: <a href='https://cloud-barista.github.io/rest-api/v0.1.0/dragonfly/' target='_blank' class='url'>https://cloud-barista.github.io/rest-api/v0.1.0/dragonfly/</a></li>
-                <li>Leader: <a href='https://github.com/kyongminkwon' title='https://github.com/kyongminkwon' target='_blank'>@kyongminkwon</a> <a href='https://github.com/hyokyungk' title='https://github.com/hyokyungk' target='_blank'>@hyokyungk</a></li>
+                <li>Maintainer: <a href='https://github.com/kyongminkwon' title='https://github.com/kyongminkwon' target='_blank'>@kyongminkwon</a> <a href='https://github.com/hyokyungk' title='https://github.com/hyokyungk' target='_blank'>@hyokyungk</a></li>
                 </ul>
 
                 </td>


### PR DESCRIPTION
O Update for the release of v0.4.0 cafemocha
- Update the 4th open conference post
- Add v0.4.0 cafemocha download link
- Add redirection to the REST API document of each framework